### PR TITLE
Fix show ping texture

### DIFF
--- a/src/pc/djui/djui_panel_playerlist.c
+++ b/src/pc/djui/djui_panel_playerlist.c
@@ -57,7 +57,7 @@ static void playerlist_update_row(u8 i, struct NetworkPlayer *np) {
         djuiPingImages[i]->texture = texture_ping_two;
     } else if (np->ping < 750) {
         djuiPingImages[i]->texture = texture_ping_one;
-    } else if (np->ping > 750) {
+    } else {
         djuiPingImages[i]->texture = texture_ping_empty;
     }
 


### PR DESCRIPTION
If `np->ping == 750`, `djuiPingImages[i]->texture` is never updated