### PR TITLE
Fix constants autogen

### DIFF
--- a/autogen/convert_constants.py
+++ b/autogen/convert_constants.py
@@ -149,6 +149,7 @@ defined_values = {
     'F3DEX_GBI_2': True,
     'DEVELOPMENT': False,
     '__ANDROID__': False,
+    'TARGET_ANDROID': False,
 }
 
 ############################################################################

--- a/autogen/convert_constants.py
+++ b/autogen/convert_constants.py
@@ -148,6 +148,7 @@ defined_values = {
     'VERSION_SH': False,
     'F3DEX_GBI_2': True,
     'DEVELOPMENT': False,
+    '__ANDROID__': False,
 }
 
 ############################################################################


### PR DESCRIPTION
`convert_constants.py` checks for `#ifdef`s to determine whether it should include following constants or not, based on the definition's value in `defined_values`
however, it wasn't updated to include the `__ANDROID__` definition in `defined_values`, so if it reads a line containing `#ifdef __ANDROID__` it will try to access an inexistent value from that table and thus will fail to convert the rest of the constants

this PR literally just adds that missing definition to `defined_values` as `False`, so it doesn't include any Android-specific constants and converts everything correctly again